### PR TITLE
🐛 Fixed bug where Lance battle goes forever

### DIFF
--- a/PokemonAdventureGame.Tests/PokemonAdventureGame.Tests/Battles/BattleTestUtils.cs
+++ b/PokemonAdventureGame.Tests/PokemonAdventureGame.Tests/Battles/BattleTestUtils.cs
@@ -1,0 +1,44 @@
+﻿using PokemonAdventureGame.Interfaces;
+using PokemonAdventureGame.Pokemon;
+using PokemonAdventureGame.PokemonTeam;
+using System.Linq;
+using Xunit;
+
+namespace PokemonAdventureGame.Tests.Battles
+{
+    public static class BattleTestUtils
+    {
+        public static void FaintPokemon<TPokemon>(ITrainer trainer)
+            where TPokemon : IPokemon
+        {
+            TrainerPokemon pokemon = trainer.PokemonTeam.FirstOrDefault(x => x.Pokemon is Gyarados);
+            FaintSpecificPokemon(pokemon);
+        }
+
+        public static void FaintSpecificPokemon(TrainerPokemon pokemon)
+        {
+            pokemon.Pokemon.ReceiveDamage(9999);
+            pokemon.SetAsFainted();
+        }
+
+        public static IPokemon GetCurrentPokemonForBattle(ITrainer trainer)
+        {
+            // This will set the "Current" property to true for the first available Pokemon.
+            _ = trainer.GetNextAvailablePokemon();
+
+            // This will return the Pokemon that will be used in the battle.
+            // NOTE: This might return a different instance of the Pokemon
+            // than "GetNextAvailablePokemon" when multiple of the same are in the team.
+            return trainer.GetCurrentPokemon();
+        }
+
+        public static void AssertPokemonAndNotFainted<TPokemon>(IPokemon pokemon)
+            where TPokemon : IPokemon
+        {
+            //string pokemonName = typeof(TPokemon).Name;
+            //Assert.Equal(pokemonName, pokemon?.GetType().Name);
+            Assert.False(pokemon.HasFainted());
+            Assert.IsType<TPokemon>(pokemon);
+        }
+    }
+}

--- a/PokemonAdventureGame.Tests/PokemonAdventureGame.Tests/Battles/LanceBattleTests.cs
+++ b/PokemonAdventureGame.Tests/PokemonAdventureGame.Tests/Battles/LanceBattleTests.cs
@@ -1,0 +1,76 @@
+﻿using PokemonAdventureGame.Factories;
+using PokemonAdventureGame.Interfaces;
+using PokemonAdventureGame.Pokemon;
+using PokemonAdventureGame.PokemonTeam;
+using PokemonAdventureGame.Trainers;
+using System.Linq;
+using Xunit;
+
+namespace PokemonAdventureGame.Tests.Battles
+{
+    public class LanceBattleTests
+    {
+        [Fact]
+        public void LanceFirstPokemon()
+        {
+            ITrainer trainer = TrainerFactory.CreateTrainer<Lance>();
+
+            IPokemon currentPokemon = BattleTestUtils.GetCurrentPokemonForBattle(trainer);
+
+            BattleTestUtils.AssertPokemonAndNotFainted<Gyarados>(currentPokemon);
+        }
+
+        [Fact]
+        public void LanceSecondPokemon()
+        {
+            ITrainer trainer = TrainerFactory.CreateTrainer<Lance>();
+
+            // Simulate Gyarados fainting
+            TrainerPokemon gyarados = trainer.PokemonTeam.FirstOrDefault(x => x.Pokemon is Gyarados);
+            gyarados.Fainted = true;
+
+            // Check next Pokemon is Dragonite
+            IPokemon currentPokemon = BattleTestUtils.GetCurrentPokemonForBattle(trainer);
+
+            BattleTestUtils.AssertPokemonAndNotFainted<Dragonite>(currentPokemon);
+        }
+
+        [Fact]
+        public void LanceThirdPokemon()
+        {
+            ITrainer trainer = TrainerFactory.CreateTrainer<Lance>();
+
+            // Simulate Gyarados fainting
+            BattleTestUtils.FaintPokemon<Gyarados>(trainer);
+
+            // Simulate first Dragonite fainting
+            TrainerPokemon firstDragonite = trainer.PokemonTeam.FirstOrDefault(x => x.Pokemon is Dragonite);
+            BattleTestUtils.FaintSpecificPokemon(firstDragonite);
+
+            // Check next Pokemon is Dragonite
+            IPokemon currentPokemon = BattleTestUtils.GetCurrentPokemonForBattle(trainer);
+
+            BattleTestUtils.AssertPokemonAndNotFainted<Dragonite>(currentPokemon);
+        }
+
+        [Fact]
+        public void LanceAllDragoniteDown()
+        {
+            ITrainer trainer = TrainerFactory.CreateTrainer<Lance>();
+
+            // Simulate Gyarados fainting
+            BattleTestUtils.FaintPokemon<Gyarados>(trainer);
+
+            // Simulate all Dragonites fainting
+            trainer.PokemonTeam
+                .Where(x => x.Pokemon is Dragonite)
+                .ToList()
+                .ForEach(x => BattleTestUtils.FaintSpecificPokemon(x));
+
+            // Check next Pokemon is Dragonite
+            IPokemon currentPokemon = BattleTestUtils.GetCurrentPokemonForBattle(trainer);
+
+            BattleTestUtils.AssertPokemonAndNotFainted<Aerodactyl>(currentPokemon);
+        }
+    }
+}

--- a/PokemonAdventureGame/Trainers/Lance.cs
+++ b/PokemonAdventureGame/Trainers/Lance.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Collections.Generic;
 using PokemonAdventureGame.Factories;
 using PokemonAdventureGame.Pokemon;
 using PokemonAdventureGame.Interfaces;
 using PokemonAdventureGame.PokemonTeam;
 using PokemonAdventureGame.BattleSystem.ConsoleUI;
+using PokemonAdventureGame.Trainers.Utils;
 
 namespace PokemonAdventureGame.Trainers
 {
@@ -41,18 +41,8 @@ namespace PokemonAdventureGame.Trainers
 
         public void SetPokemonAsCurrent(IPokemon pokemon)
         {
-            Parallel.ForEach(PokemonTeam, pkmn =>
-            {
-                if (pkmn.Current)
-                {
-                    pkmn.Current = false;
-                }
-
-                if (pkmn.Pokemon.GetType().Name == pokemon.GetType().Name && !pkmn.Pokemon.HasFainted())
-                {
-                    pkmn.Current = true;
-                }
-            });
+            // Prevent setting a Pokemon as current if it has fainted.
+            TrainerUtils.UpdateCurrentBattlePokemon(PokemonTeam, pokemon);
         }
 
         public IPokemon GetNextAvailablePokemon()

--- a/PokemonAdventureGame/Trainers/Lance.cs
+++ b/PokemonAdventureGame/Trainers/Lance.cs
@@ -48,7 +48,7 @@ namespace PokemonAdventureGame.Trainers
                     pkmn.Current = false;
                 }
 
-                if (pkmn.Pokemon.GetType().Name == pokemon.GetType().Name)
+                if (pkmn.Pokemon.GetType().Name == pokemon.GetType().Name && !pkmn.Pokemon.HasFainted())
                 {
                     pkmn.Current = true;
                 }

--- a/PokemonAdventureGame/Trainers/Utils/TrainerUtils.cs
+++ b/PokemonAdventureGame/Trainers/Utils/TrainerUtils.cs
@@ -1,0 +1,32 @@
+﻿using PokemonAdventureGame.Interfaces;
+using PokemonAdventureGame.PokemonTeam;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PokemonAdventureGame.Trainers.Utils
+{
+    public static class TrainerUtils
+    {
+        /// <summary>
+        /// Utility that should be used for trainers that have more than 1 Pokemon of the same type.
+        /// Lance for instance, has multiple Dragonite.
+        /// </summary>
+        /// <param name="trainer">Pokemon trainer</param>
+        /// <param name="pokemon">Desired Pokemon</param>
+        /// <returns>Return selected Pokemon as current.</returns>
+        public static void UpdateCurrentBattlePokemon(List<TrainerPokemon> pokemonTeam, IPokemon pokemon)
+        {
+            // Make all Pokemon in the team not current.
+            pokemonTeam.ForEach(p => p.Current = false);
+
+            var currentPokemon = pokemonTeam.FirstOrDefault(p =>
+                p.Pokemon.GetType() == pokemon.GetType() && !p.Pokemon.HasFainted());
+
+            if (currentPokemon != null)
+            {
+                // Make sure only 1 of the same Pokemon is current.
+                currentPokemon.Current = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have enjoyed playing the game, and it was fun to see how everything worked behind the scenes. :)

When playing against Lance and fainted the first **Dragonite**, his next Pokemon was the same fainted **Dragonite**.

When debugging, I noticed that `GetNextAvailablePokemon()` selects second **Dragonite** but `GetCurrentPokemon()` selects fainted **Dragonite**. I wanted to update `GetCurrentPokemon()`, but that would change the battle logic, so I changed `SetPokemonAsCurrent` instead.

The issue is 2 parts:
1. All Pokemon of the same type are marked as `Current`
2. Fainted Pokemon are set as `Current`

I have added a couple of tests, `LanceBattleTests`, to test the bug and existing behaviour to ensure I haven't broken any existing logic. The bug was reproduced with the `LanceBattleTests.LanceThirdPokemon` test.

The fix is to make only 1 non-fainted Pokemon current to avoid any other bugs when multiple Pokemon are current.

Feel free to change the code any way you like. :)